### PR TITLE
manifest: add "config_flow": true to enable UI setup

### DIFF
--- a/custom_components/naim_media_player/manifest.json
+++ b/custom_components/naim_media_player/manifest.json
@@ -10,5 +10,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/jorourke/naim-atom-home-assistant/issues",
   "requirements": [],
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "config_flow": true
 }


### PR DESCRIPTION
Home Assistant requires `"config_flow": true` in `manifest.json` for to enable a config flow. Tested locally: integration is discoverable and adds Naim Uniti Atom via UI