### PR TITLE
🐛 fix: reduce log noise when device is offline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,22 @@ class NaimPlayerState:
 
 **Run tests:**
 ```bash
-pytest tests/
+uv run pytest tests/
+```
+
+**Check formatting:**
+```bash
+uv run ruff format --check custom_components/ tests/
+```
+
+**Fix formatting:**
+```bash
+uv run ruff format custom_components/ tests/
+```
+
+**Run linter:**
+```bash
+uv run ruff check custom_components/ tests/
 ```
 
 **Test structure:**
@@ -335,12 +350,22 @@ Before merging changes:
 
 **Run tests:**
 ```bash
-pytest tests/ -v
+uv run pytest tests/ -v
 ```
 
-**Check code quality:**
+**Check formatting:**
 ```bash
-# No linting configured yet - use your editor's Python linter
+uv run ruff format --check custom_components/ tests/
+```
+
+**Fix formatting:**
+```bash
+uv run ruff format custom_components/ tests/
+```
+
+**Run linter:**
+```bash
+uv run ruff check custom_components/ tests/
 ```
 
 **Create release:**

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Please report your experience with other Naim devices to help expand this list.
 
 ## Changelog
 
+### v0.2.2
+- **Improved Offline Handling**: Entity shows as "Unavailable" when device is offline instead of spamming error logs
+- **Reduced Log Noise**: Connection failures now log at DEBUG level instead of ERROR
+- **HTTP Timeout**: Added 5-second timeout to HTTP requests to prevent long hangs during polling
+
 ### v0.2.0
 - **Real-time WebSocket Updates**: Live status updates without polling delays
 - **Improved Volume Control**: Debounce mechanism prevents UI feedback loops

--- a/TODO.md
+++ b/TODO.md
@@ -29,12 +29,12 @@ Keep existing working integration, add another config entry pointing to same dev
 - [x] Already fixed in current codebase - close the issue
 
 ### Issue #4: Repeated error messages if Atom is offline
-- [ ] Add `_attr_available` property tracking to `NaimPlayer`
-- [ ] Set `_attr_available = False` when device is unreachable in `async_update`
-- [ ] Set `_attr_available = True` when connection succeeds
-- [ ] Change log level from ERROR to DEBUG/WARNING in `websocket.py:72` for connection failures
-- [ ] Change log level from ERROR to DEBUG in `media_player.py:365` for expected offline states
-- [ ] Add explicit timeout (5s) to HTTP requests in `async_get_current_value`
+- [x] Add `_attr_available` property tracking to `NaimPlayer`
+- [x] Set `_attr_available = False` when device is unreachable in `async_update`
+- [x] Set `_attr_available = True` when connection succeeds
+- [x] Change log level from ERROR to DEBUG/WARNING in `websocket.py:72` for connection failures
+- [x] Change log level from ERROR to DEBUG in `media_player.py:365` for expected offline states
+- [x] Add explicit timeout (5s) to HTTP requests in `async_get_current_value`
 
 ### Issue #5: Lose config after cutting power
 - [ ] Clear `_buffer` on reconnection attempt in `websocket.py:_socket_listener` (add `self._buffer = ""` at start of while loop)

--- a/custom_components/naim_media_player/client.py
+++ b/custom_components/naim_media_player/client.py
@@ -79,7 +79,8 @@ class NaimWebSocketClient:
 
             except Exception as error:
                 self._connected = False
-                _LOGGER.error(
+                # Log as debug since device being offline is expected during normal operation
+                _LOGGER.debug(
                     "WebSocket connection failed (%s:%d): %s. Retrying in %s seconds",
                     self.ip_address,
                     self.port,

--- a/custom_components/naim_media_player/manifest.json
+++ b/custom_components/naim_media_player/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/jorourke/naim-atom-home-assistant/issues",
   "requirements": [],
-  "version": "0.2.1"
+  "version": "0.2.2"
 }

--- a/custom_components/naim_media_player/websocket.py
+++ b/custom_components/naim_media_player/websocket.py
@@ -69,7 +69,8 @@ class NaimWebSocket:
 
             except Exception as error:
                 self._connected = False
-                _LOGGER.error(
+                # Log as debug since device being offline is expected during normal operation
+                _LOGGER.debug(
                     "WebSocket connection failed (%s:%d): %s. Retrying in %s seconds",
                     self.ip_address,
                     self.port,


### PR DESCRIPTION
## Summary

- Adds `_attr_available` property to track device availability in Home Assistant
- Sets entity as "unavailable" when device is unreachable instead of logging ERROR repeatedly
- Changes WebSocket and HTTP connection failure logs from ERROR to DEBUG level
- Adds 5-second timeout to HTTP requests to prevent long hangs during polls
- Updates CLAUDE.md to use `uv run pytest` for running tests

## Fixes

Closes #4 - Repeated error messages in log if Atom is offline

## Changes

When the Naim device is offline:
- The media player entity will show as "Unavailable" in Home Assistant
- Connection failures are logged at DEBUG level instead of ERROR
- HTTP requests timeout after 5 seconds instead of hanging indefinitely

When the device comes back online:
- The entity automatically becomes available again
- A single INFO log message is logged for the state transition

## Test plan

- [ ] Run `uv run pytest tests/` - all tests pass
- [ ] Deploy to Home Assistant with device offline - verify no ERROR spam in logs
- [ ] Turn device on - verify entity becomes available
- [ ] Turn device off - verify entity becomes unavailable with minimal logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks entity unavailable when device is offline, adds 5s HTTP timeouts, and downgrades connection errors to DEBUG; bumps version to 0.2.2 and updates docs.
> 
> - **Integration (Naim Media Player)**:
>   - **Availability tracking**: Add `_attr_available` and toggle in `async_update()` based on HTTP reachability.
>   - **HTTP timeouts**: Use 5s `aiohttp.ClientTimeout` in `async_get_current_value()`.
>   - **Logging**: Downgrade connection failures from ERROR to DEBUG in `client.py`, `websocket.py`, and HTTP fetch paths in `media_player.py`; INFO when device becomes available.
> - **Version**:
>   - Bump `manifest.json` to `v0.2.2`.
> - **Docs**:
>   - Add `v0.2.2` changelog to `README.md`.
>   - Update `CLAUDE.md` Quickstart: use `uv run pytest` and add `ruff` format/lint commands.
>   - Mark Issue #4 checklist items as done in `TODO.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ba657f21cab4c1de427546c9ea173f56cdf73b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->