### PR TITLE
Fix release workflow deploy key push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - name: Determine version bump type
         id: bump-type


### PR DESCRIPTION
## Summary
- Configure the auto-release checkout to use RELEASE_DEPLOY_KEY so the version-bump push can use the deploy key ruleset bypass.
- This follow-up PR is intended to produce the missed v0.4.1 patch release after the original release job was blocked by the master ruleset.

## Release context
This should create v0.4.1 for the v0.4.0 architecture cleanup and HA stage deploy tooling from PR #17.

## Test Plan
- [x] uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yaml')); print('yaml ok')"