### PR TITLE
Configurable volume step (1–20%) with correct arithmetic and reconfigure support

### DIFF
--- a/custom_components/naim_media_player/config_flow.py
+++ b/custom_components/naim_media_player/config_flow.py
@@ -15,7 +15,14 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig, SelectSelectorMode
+from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
 from .const import (
     CONF_SERIAL,
@@ -143,8 +150,8 @@ class NaimConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_IP_ADDRESS, default=suggested_values[CONF_IP_ADDRESS]): str,
                 vol.Optional(CONF_NAME, default=suggested_values[CONF_NAME]): str,
                 vol.Optional("entity_id", default=suggested_values["entity_id"]): str,
-                vol.Optional(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): vol.All(
-                    vol.Coerce(float), vol.In([1, 5, 10])
+                vol.Required(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): NumberSelector(
+                    NumberSelectorConfig(min=1, max=20, step=1, mode=NumberSelectorMode.BOX)
                 ),
             }
         )
@@ -310,7 +317,19 @@ class NaimOptionsFlow(config_entries.OptionsFlow):
             selected_names = user_input.get(CONF_SOURCES, [])
             selected_sources = {name: self._available_sources[name] for name in selected_names}
 
-            return self.async_create_entry(title="", data={CONF_SOURCES: selected_sources})
+            return self.async_create_entry(
+                title="",
+                data={
+                    CONF_SOURCES: selected_sources,
+                    CONF_VOLUME_STEP: user_input.get(
+                        CONF_VOLUME_STEP,
+                        self._config_entry.options.get(
+                            CONF_VOLUME_STEP,
+                            self._config_entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP),
+                        ),
+                    ),
+                },
+            )
 
         # Get currently configured sources (from options first, then data, then empty)
         current_sources = self._config_entry.options.get(CONF_SOURCES, self._config_entry.data.get(CONF_SOURCES, {}))
@@ -319,6 +338,12 @@ class NaimOptionsFlow(config_entries.OptionsFlow):
         # If no current sources, default to all available
         if not current_source_names:
             current_source_names = list(self._available_sources.keys())
+
+        # Get current volume step (from options first, then data, then default)
+        current_volume_step = self._config_entry.options.get(
+            CONF_VOLUME_STEP,
+            self._config_entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP),
+        )
 
         # Build the schema
         source_names = list(self._available_sources.keys())
@@ -330,6 +355,9 @@ class NaimOptionsFlow(config_entries.OptionsFlow):
                         multiple=True,
                         mode=SelectSelectorMode.LIST,
                     )
+                ),
+                vol.Required(CONF_VOLUME_STEP, default=current_volume_step): NumberSelector(
+                    NumberSelectorConfig(min=1, max=20, step=1, mode=NumberSelectorMode.BOX)
                 ),
             }
         )

--- a/custom_components/naim_media_player/config_flow.py
+++ b/custom_components/naim_media_player/config_flow.py
@@ -38,6 +38,19 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Shared selector for the volume step field, used by both the setup and options
+# flows. Wrap it in vol.All(..., vol.Coerce(int)) in a schema to reject/coerce
+# fractional input server-side.
+VOLUME_STEP_SELECTOR = NumberSelector(NumberSelectorConfig(min=1, max=20, step=1, mode=NumberSelectorMode.BOX))
+
+
+def _get_volume_step(config_entry: config_entries.ConfigEntry) -> int:
+    """Return the configured volume step, preferring options over data."""
+    return config_entry.options.get(
+        CONF_VOLUME_STEP,
+        config_entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP),
+    )
+
 
 async def async_get_available_inputs(hass, ip_address: str, port: int = DEFAULT_HTTP_PORT) -> dict[str, str] | None:
     """Fetch available inputs from the Naim device.
@@ -150,8 +163,8 @@ class NaimConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_IP_ADDRESS, default=suggested_values[CONF_IP_ADDRESS]): str,
                 vol.Optional(CONF_NAME, default=suggested_values[CONF_NAME]): str,
                 vol.Optional("entity_id", default=suggested_values["entity_id"]): str,
-                vol.Required(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): NumberSelector(
-                    NumberSelectorConfig(min=1, max=20, step=1, mode=NumberSelectorMode.BOX)
+                vol.Required(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): vol.All(
+                    VOLUME_STEP_SELECTOR, vol.Coerce(int)
                 ),
             }
         )
@@ -305,65 +318,54 @@ class NaimOptionsFlow(config_entries.OptionsFlow):
         """Handle the initial options step."""
         ip_address = self._config_entry.data.get(CONF_IP_ADDRESS)
 
-        # Fetch available sources from the device
+        # Try to fetch available sources from the device. The device may be
+        # unreachable; volume step can still be configured in that case, so we
+        # don't abort here — we just skip the source selection field.
         self._available_sources = await async_get_available_inputs(self.hass, ip_address) or {}
+        device_reachable = bool(self._available_sources)
 
-        if not self._available_sources:
-            # Can't reach device, show error
-            return self.async_abort(reason="cannot_connect")
+        # Currently configured sources (from options first, then data, then empty)
+        current_sources = self._config_entry.options.get(CONF_SOURCES, self._config_entry.data.get(CONF_SOURCES, {}))
 
         if user_input is not None:
-            # Build the selected sources dict
-            selected_names = user_input.get(CONF_SOURCES, [])
-            selected_sources = {name: self._available_sources[name] for name in selected_names}
+            data = {
+                CONF_VOLUME_STEP: int(user_input.get(CONF_VOLUME_STEP, _get_volume_step(self._config_entry))),
+            }
 
-            return self.async_create_entry(
-                title="",
-                data={
-                    CONF_SOURCES: selected_sources,
-                    CONF_VOLUME_STEP: user_input.get(
-                        CONF_VOLUME_STEP,
-                        self._config_entry.options.get(
-                            CONF_VOLUME_STEP,
-                            self._config_entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP),
-                        ),
-                    ),
-                },
+            if device_reachable:
+                # Build the selected sources dict from the refreshed device list.
+                selected_names = user_input.get(CONF_SOURCES, [])
+                data[CONF_SOURCES] = {name: self._available_sources[name] for name in selected_names}
+            else:
+                # Couldn't refresh sources from the device; keep the existing ones.
+                data[CONF_SOURCES] = current_sources
+
+            return self.async_create_entry(title="", data=data)
+
+        current_volume_step = _get_volume_step(self._config_entry)
+
+        schema_dict: dict[Any, Any] = {}
+        if device_reachable:
+            current_source_names = list(current_sources.keys()) if current_sources else []
+            # If no current sources, default to all available
+            if not current_source_names:
+                current_source_names = list(self._available_sources.keys())
+
+            source_names = list(self._available_sources.keys())
+            schema_dict[vol.Required(CONF_SOURCES, default=current_source_names)] = SelectSelector(
+                SelectSelectorConfig(
+                    options=source_names,
+                    multiple=True,
+                    mode=SelectSelectorMode.LIST,
+                )
             )
 
-        # Get currently configured sources (from options first, then data, then empty)
-        current_sources = self._config_entry.options.get(CONF_SOURCES, self._config_entry.data.get(CONF_SOURCES, {}))
-        current_source_names = list(current_sources.keys()) if current_sources else []
-
-        # If no current sources, default to all available
-        if not current_source_names:
-            current_source_names = list(self._available_sources.keys())
-
-        # Get current volume step (from options first, then data, then default)
-        current_volume_step = self._config_entry.options.get(
-            CONF_VOLUME_STEP,
-            self._config_entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP),
-        )
-
-        # Build the schema
-        source_names = list(self._available_sources.keys())
-        schema = vol.Schema(
-            {
-                vol.Required(CONF_SOURCES, default=current_source_names): SelectSelector(
-                    SelectSelectorConfig(
-                        options=source_names,
-                        multiple=True,
-                        mode=SelectSelectorMode.LIST,
-                    )
-                ),
-                vol.Required(CONF_VOLUME_STEP, default=current_volume_step): NumberSelector(
-                    NumberSelectorConfig(min=1, max=20, step=1, mode=NumberSelectorMode.BOX)
-                ),
-            }
+        schema_dict[vol.Required(CONF_VOLUME_STEP, default=current_volume_step)] = vol.All(
+            VOLUME_STEP_SELECTOR, vol.Coerce(int)
         )
 
         return self.async_show_form(
             step_id="init",
-            data_schema=schema,
+            data_schema=vol.Schema(schema_dict),
             description_placeholders={"device_name": self._config_entry.data.get(CONF_NAME, "Naim Device")},
         )

--- a/custom_components/naim_media_player/media_player.py
+++ b/custom_components/naim_media_player/media_player.py
@@ -46,7 +46,10 @@ async def async_setup_entry(
     ip_address = entry.data[CONF_IP_ADDRESS]
     name = entry.data.get(CONF_NAME, DEFAULT_NAME)
     entity_id = entry.data.get("entity_id")
-    volume_step = entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP)
+    volume_step = entry.options.get(
+        CONF_VOLUME_STEP,
+        entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP),
+    )
     sources = entry.options.get(CONF_SOURCES) or entry.data.get(CONF_SOURCES)
     serial = entry.data.get(CONF_SERIAL)
 
@@ -240,15 +243,17 @@ class NaimPlayer(MediaPlayerEntity):
 
     async def async_volume_up(self) -> None:
         """Increase volume by one configured step."""
-        new_volume = min(1.0, self._state.volume + self._volume_step)
-        new_volume = round_to_nearest(new_volume, step=self._volume_step)
-        await self._client.set_volume(int(new_volume * 100))
+        current_percent = int(round(self._state.volume * 100))
+        step_percent = int(round(self._volume_step * 100))
+        target_percent = min(100, current_percent + step_percent)
+        await self._client.set_volume(target_percent)
 
     async def async_volume_down(self) -> None:
         """Decrease volume by one configured step."""
-        new_volume = max(0.0, self._state.volume - self._volume_step)
-        new_volume = round_to_nearest(new_volume, step=self._volume_step)
-        await self._client.set_volume(int(new_volume * 100))
+        current_percent = int(round(self._state.volume * 100))
+        step_percent = int(round(self._volume_step * 100))
+        target_percent = max(0, current_percent - step_percent)
+        await self._client.set_volume(target_percent)
 
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute or unmute volume."""

--- a/custom_components/naim_media_player/media_player.py
+++ b/custom_components/naim_media_player/media_player.py
@@ -32,11 +32,6 @@ PLATFORMS = [Platform.MEDIA_PLAYER]
 _LOGGER = logging.getLogger(__name__)
 
 
-def round_to_nearest(val: float, step: float = 0.01) -> float:
-    """Round a value to the nearest step."""
-    return round(val / step) * step
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -239,7 +234,7 @@ class NaimPlayer(MediaPlayerEntity):
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level."""
         volume = max(0.0, min(1.0, volume))
-        await self._client.set_volume(int(round_to_nearest(volume) * 100))
+        await self._client.set_volume(int(round(volume * 100)))
 
     async def async_volume_up(self) -> None:
         """Increase volume by one configured step."""

--- a/custom_components/naim_media_player/translations/en.json
+++ b/custom_components/naim_media_player/translations/en.json
@@ -8,7 +8,7 @@
                   "ip_address": "IP Address (e.g., 192.168.1.127)",
                   "name": "Name (e.g., Naim Atom)",
                   "entity_id": "Entity ID (e.g., naim_atom)",
-                  "volume_step": "Volume Step (e.g., 5)"
+                  "volume_step": "Volume Step % (1–20)"
               }
           },
           "sources": {
@@ -26,7 +26,7 @@
           "timeout": "Connection timed out",
           "already_configured": "This Naim device is already configured",
           "invalid_entity_id": "Invalid entity ID",
-          "invalid_volume_step": "Volume step must be 1, 5, or 10"
+          "invalid_volume_step": "Volume step must be between 1 and 20"
       },
       "abort": {
           "already_configured": "This Naim device is already configured"
@@ -38,7 +38,8 @@
               "title": "Configure Sources",
               "description": "Select which input sources to show for {device_name}.",
               "data": {
-                  "sources": "Available Sources"
+                  "sources": "Available Sources",
+                  "volume_step": "Volume Step % (1–20)"
               }
           }
       },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -597,14 +597,16 @@ async def test_options_flow_submit(hass: HomeAssistant) -> None:
     }
 
 
-async def test_options_flow_cannot_connect(hass: HomeAssistant) -> None:
-    """Test options flow aborts when device not reachable."""
+async def test_options_flow_volume_step_when_unreachable(hass: HomeAssistant) -> None:
+    """Test volume step can still be changed when the device is unreachable."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="Test Naim",
         data={
             CONF_IP_ADDRESS: "192.168.1.100",
             CONF_NAME: "Test Naim",
+            CONF_SOURCES: {"Analog 1": "ana1"},
+            CONF_VOLUME_STEP: 3,
         },
     )
 
@@ -615,10 +617,22 @@ async def test_options_flow_cannot_connect(hass: HomeAssistant) -> None:
         flow = NaimOptionsFlow(entry)
         flow.hass = hass
 
+        # Form is still shown, with the volume step field but no sources field.
         result = await flow.async_step_init()
+        assert result["type"] == "form"
+        assert result["step_id"] == "init"
+        schema_keys = {str(key) for key in result["data_schema"].schema}
+        assert CONF_VOLUME_STEP in schema_keys
+        assert CONF_SOURCES not in schema_keys
 
-    assert result["type"] == "abort"
-    assert result["reason"] == "cannot_connect"
+        # Submitting a new volume step preserves the existing sources.
+        result = await flow.async_step_init({CONF_VOLUME_STEP: 7})
+
+    assert result["type"] == "create_entry"
+    assert result["data"] == {
+        CONF_SOURCES: {"Analog 1": "ana1"},
+        CONF_VOLUME_STEP: 7,
+    }
 
 
 async def test_options_flow_defaults_to_all_sources(hass: HomeAssistant) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -126,7 +126,7 @@ async def test_form_invalid_volume_step(hass: HomeAssistant) -> None:
                 CONF_IP_ADDRESS: "192.168.1.100",
                 CONF_NAME: DEFAULT_NAME,
                 "entity_id": "test_naim",
-                CONF_VOLUME_STEP: 3,  # Invalid value - not in [1, 5, 10]
+                CONF_VOLUME_STEP: 25,  # Invalid value - outside NumberSelector range 1-20
             },
         )
 
@@ -588,10 +588,13 @@ async def test_options_flow_submit(hass: HomeAssistant) -> None:
         await flow.async_step_init()
 
         # Submit with new selection
-        result = await flow.async_step_init({CONF_SOURCES: ["Spotify", "Digital 1"]})
+        result = await flow.async_step_init({CONF_SOURCES: ["Spotify", "Digital 1"], CONF_VOLUME_STEP: 5})
 
     assert result["type"] == "create_entry"
-    assert result["data"] == {CONF_SOURCES: {"Spotify": "spotify", "Digital 1": "dig1"}}
+    assert result["data"] == {
+        CONF_SOURCES: {"Spotify": "spotify", "Digital 1": "dig1"},
+        CONF_VOLUME_STEP: 5,
+    }
 
 
 async def test_options_flow_cannot_connect(hass: HomeAssistant) -> None:

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -253,6 +253,55 @@ async def test_volume_boundaries(mock_player):
     mock_player._client.set_volume.assert_called_once_with(0)
 
 
+async def test_volume_up_even_steps_step_3(mock_player):
+    """Step 3% from 30% produces even jumps: 33, 36, 39."""
+    mock_player._volume_step = 0.03
+    mock_player._state.volume = 0.30
+    for expected in (33, 36, 39):
+        await mock_player.async_volume_up()
+        mock_player._client.set_volume.assert_called_once_with(expected)
+        mock_player._client.set_volume.reset_mock()
+        mock_player._state.volume = expected / 100
+
+
+async def test_volume_up_even_steps_step_7(mock_player):
+    """Step 7% from 56% produces even jumps: 63, 70, 77."""
+    mock_player._volume_step = 0.07
+    mock_player._state.volume = 0.56
+    for expected in (63, 70, 77):
+        await mock_player.async_volume_up()
+        mock_player._client.set_volume.assert_called_once_with(expected)
+        mock_player._client.set_volume.reset_mock()
+        mock_player._state.volume = expected / 100
+
+
+async def test_volume_down_even_steps_step_3(mock_player):
+    """Step 3% down from 48% produces even jumps: 45, 42, 39."""
+    mock_player._volume_step = 0.03
+    mock_player._state.volume = 0.48
+    for expected in (45, 42, 39):
+        await mock_player.async_volume_down()
+        mock_player._client.set_volume.assert_called_once_with(expected)
+        mock_player._client.set_volume.reset_mock()
+        mock_player._state.volume = expected / 100
+
+
+async def test_volume_up_clamps_to_100(mock_player):
+    """Volume up near the top clamps to 100."""
+    mock_player._volume_step = 0.07
+    mock_player._state.volume = 0.96
+    await mock_player.async_volume_up()
+    mock_player._client.set_volume.assert_called_once_with(100)
+
+
+async def test_volume_down_clamps_to_0(mock_player):
+    """Volume down near the bottom clamps to 0."""
+    mock_player._volume_step = 0.07
+    mock_player._state.volume = 0.04
+    await mock_player.async_volume_down()
+    mock_player._client.set_volume.assert_called_once_with(0)
+
+
 async def test_mute(mock_player):
     """Test mute delegates to client."""
     await mock_player.async_mute_volume(True)


### PR DESCRIPTION
## What this does

Three related improvements to the volume step feature:

1. **Flexible range**: Replaces the fixed 1/5/10 dropdown with a NumberSelector box accepting any integer from 1 to 20.

2. **Correct step arithmetic**: Replaces `round_to_nearest` step-grid snapping with integer percentage arithmetic. Step 3 now correctly produces 30, 33, 36, 39 instead of 30, 32, 36, 39.

3. **Reconfigurable after setup**: Adds the volume step field to the options flow, so users can change it via Configure without removing and re-adding the integration.

## Why

The current 1/5/10 presets don't cover some use cases. I've been using 2% on my Naim Uniti Atom because I find 5% is too coarse for me.

The step-grid rounding also produces uneven jumps for values like 3 (observed: 30, 32, 36, 39, 42, 44, 48). Integer arithmetic fixes this.

Being able to adjust the step via Configure without deleting the integration lets users experiment to find their preferred value.

## Changes

- `config_flow.py`: NumberSelector (1–20, box mode) in setup and options flow; volume step saved in options data
- `media_player.py`: Read volume_step from `entry.options` first; integer percent arithmetic in volume up/down
- `translations/en.json`: Updated labels and error messages; added volume_step to options form
- `tests/test_media_player.py`: Added tests for step 3, step 7, and boundary clamping

## Testing

Tested on Naim Uniti Atom. Step 3 gives 30, 33, 36, 39. Step 7 gives 56, 63, 70, 77. Reconfigure via options flow works: the integration reloads and picks up the new step immediately.

Thanks for the great integration!