### PR TITLE
feat: address the fast-follow code-review findings in issue #21

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@
 
 This is a **HACS (Home Assistant Community Store)** custom integration that provides local network control of **Naim audio devices** (primarily Naim Atom). The integration creates a fully-featured media player entity in Home Assistant with real-time status updates.
 
-**Version:** 0.2.0
+**Version:** 0.5.1 (see `manifest.json` for the current release)
 **Type:** Local IoT integration (no cloud dependency)
-**Communication:** Dual protocol (HTTP API + WebSocket)
+**Communication:** Dual protocol (HTTP API + WebSocket), consolidated into one client
 
 ## Architecture
 
@@ -15,22 +15,25 @@ Home Assistant Media Player Entity
          ↓
     NaimPlayer (media_player.py)
          ↓
+    NaimClient (client.py)
     ┌────────────┬────────────┐
     ↓            ↓            ↓
-HTTP Client  WebSocket   State Manager
-(15081)      (4545)      (thread-safe)
-    ↓            ↓            ↓
+HTTP requests  WebSocket   NaimPlayerState (state.py)
+(15081)        (4545)      (asyncio.Lock, single source of truth)
+    ↓            ↓
         Naim Atom Device
 ```
 
 ### Core Components
 
-- **`media_player.py`** (690 lines) - Main entity implementation with debounce logic
-- **`client.py`** (241 lines) - HTTP API client + WebSocket client
-- **`websocket.py`** (89 lines) - Low-level TCP socket wrapper
-- **`config_flow.py`** (140 lines) - UI configuration flow
+- **`media_player.py`** - Thin HA entity adapter; delegates I/O to `client.py` and reads all state from `state.py`
+- **`client.py`** - Consolidated HTTP API client + WebSocket listener (`NaimClient`); owns retries/backoff and WebSocket reconnect/buffering
+- **`state.py`** - `NaimPlayerState`/`MediaInfo`; single source of truth for device state, updated only via `NaimPlayerState.update(...)` under an `asyncio.Lock`, with debounce and value-guard logic
+- **`config_flow.py`** - UI setup + options flow; device discovery (serial, inputs) and identity (unique_id) resolution
 - **`const.py`** - Configuration constants (ports, intervals, steps)
 - **`exceptions.py`** - Custom exception hierarchy
+
+There is no separate `websocket.py` module — the WebSocket listener, reconnect loop, and buffered JSON parsing live in `client.py` alongside the HTTP methods.
 
 ### Communication Protocols
 
@@ -57,23 +60,24 @@ Used for **real-time status updates**:
 
 ### Debounce Mechanism (Critical)
 ```python
-# Prevent feedback loops between UI actions and WebSocket updates
-_last_user_volume_action: float  # 2 second window
-_last_user_mute_action: float    # 2 second window
-_debounce_timeout: float = 2.0   # Ignore device echo
-_update_debounce_timeout: float = 1.0  # Rate limit polling
+# state.py — NaimPlayerState
+DEBOUNCED_FIELDS = {"volume", "muted"}
+_debounce_timestamps: dict[str, float]  # per-field, set on source="user" updates
+_debounce_timeout: float = 2.0          # 2 second window; non-"user" updates to a
+                                         # debounced field are ignored inside this window
 ```
 
 **Why:** When user changes volume via UI → HTTP command → device updates → WebSocket echoes change → UI would flicker. Debounce prevents this.
 
 ### Error Handling Pattern
+`client.py` never optimistically writes state and then reverts it. Each setter sends the HTTP
+command first; `NaimPlayerState.update(...)` (with `source="user"`) only runs after the command
+succeeds. If the HTTP call raises, the exception propagates and state is left untouched — a
+later poll or WebSocket update is free to correct it:
 ```python
-try:
-    await self._api_client.set_value(...)
-except aiohttp.ClientError as error:
-    _LOGGER.error("Error: %s", error)
-    # Revert optimistic state update
-    await self._state.update(old_value)
+async def set_volume(self, volume: int) -> None:
+    await self.set_value("levels/room", {"volume": volume})  # raises on failure
+    await self._state.update(source="user", volume=volume / 100)  # only reached on success
 ```
 
 ### Retry Logic
@@ -81,10 +85,14 @@ except aiohttp.ClientError as error:
 for retry in range(max_retries):
     try:
         return await operation()
-    except Exception:
+    except (aiohttp.ClientError, asyncio.TimeoutError, ValueError):
         if retry < max_retries - 1:
             await asyncio.sleep(2**retry)  # Exponential backoff
 ```
+Polling (`poll_state`) passes `single_attempt=True` through `_get_json_safe`/`_get_json`/`_request`
+so a slow/unreachable device never blocks `async_update` for the full retry duration; the safe
+path (`_get_json_safe`) always returns `None` on failure instead of raising, and malformed JSON
+bodies are treated the same as any other failed attempt (never escape `poll_state`).
 
 ### State Management
 ```python
@@ -136,9 +144,12 @@ uv run ruff check custom_components/ tests/
 ```
 
 **Test structure:**
-- `test_client.py` - API client and WebSocket tests
+- `test_client.py` - HTTP client and WebSocket tests
+- `test_state.py` - `NaimPlayerState`/`MediaInfo` behavior tests
 - `test_media_player.py` - Entity behavior tests
 - `test_config_flow.py` - Configuration UI tests
+- `test_init.py` - Integration setup/options-reload tests
+- `test_ha_stage.py` - `scripts/ha_stage.py` deploy helper tests (mocks subprocess/HTTP)
 - `conftest.py` - Shared fixtures
 
 **Mocking:**
@@ -150,27 +161,32 @@ uv run ruff check custom_components/ tests/
 
 ### Adding a New Source
 
-1. Update `SOURCE_TO_INPUT_MAP` in media_player.py:
+Sources are normally discovered live from the device's `/inputs` endpoint during config flow
+setup (and refreshed in the options flow), and stored per-entry as `CONF_SOURCES`. Update
+`NaimPlayer.DEFAULT_SOURCE_MAP` in media_player.py only to extend the hardcoded fallback used
+when a device's inputs can't be discovered:
 ```python
-SOURCE_TO_INPUT_MAP = {
+DEFAULT_SOURCE_MAP = {
     "New Source": "newsource",  # Add here
     # ...
 }
 ```
 
-2. Add to config flow if needed (config_flow.py)
-
 ### Changing Debounce Timing
 
-Edit constants in media_player.py:
+Edit the constant in state.py:
 ```python
-_debounce_timeout: float = 2.0  # User action ignore window
-_update_debounce_timeout: float = 1.0  # Polling rate limit
+_debounce_timeout: float = 2.0  # User action ignore window, applies to DEBOUNCED_FIELDS
 ```
+
+### Changing the Volume Step
+
+The volume step is user-configurable (1-20%) via `CONF_VOLUME_STEP` in the config/options flow;
+`DEFAULT_VOLUME_STEP` in const.py is only the pre-filled default (5%).
 
 ### Adding New Device Commands
 
-1. Add method to `NaimApiClient` in client.py
+1. Add method to `NaimClient` in client.py
 2. Add corresponding method to `NaimPlayer` entity
 3. Update supported features flags if needed
 
@@ -178,10 +194,13 @@ _update_debounce_timeout: float = 1.0  # Polling rate limit
 
 ```python
 DOMAIN = "naim_media_player"
-DEFAULT_PORT = 4545           # WebSocket
-DEFAULT_HTTP_PORT = 15081     # HTTP API
-VOLUME_STEP = 0.05            # 5% default
-SOCKET_RECONNECT_INTERVAL = 5  # seconds
+DEFAULT_PORT = 4545              # WebSocket
+DEFAULT_HTTP_PORT = 15081        # HTTP API
+CONF_VOLUME_STEP = "volume_step" # user-configurable, 1-20 (integer percent)
+DEFAULT_VOLUME_STEP = 5          # 5% default
+CONF_SOURCES = "sources"         # discovered/selected input map, stored per config entry
+CONF_SERIAL = "serial"           # device serial, used for identity + device registry
+SOCKET_RECONNECT_INTERVAL = 5    # seconds
 ```
 
 ## Naim Device API Reference
@@ -243,23 +262,28 @@ SOCKET_RECONNECT_INTERVAL = 5  # seconds
 
 ```
 custom_components/naim_media_player/
-├── __init__.py           # Platform setup
+├── __init__.py           # Integration setup/unload, options-reload listener
 ├── const.py              # Constants
 ├── exceptions.py         # Custom exceptions
-├── client.py             # HTTP + WebSocket clients
-├── websocket.py          # Low-level socket wrapper
+├── state.py              # NaimPlayerState / MediaInfo — single source of truth
+├── client.py             # Consolidated HTTP API client + WebSocket listener
 ├── media_player.py       # Main entity implementation
-├── config_flow.py        # UI configuration
+├── config_flow.py        # UI configuration + options flow
 ├── manifest.json         # Integration metadata
 └── translations/
     └── en.json           # UI strings
 
+scripts/
+└── ha_stage.py           # Deploy helper (needs HASS_SERVER/HASS_TOKEN; not part of the test gates)
+
 tests/
 ├── conftest.py           # Pytest fixtures
 ├── test_client.py        # Client tests
+├── test_state.py         # State management tests
 ├── test_media_player.py  # Entity tests
 ├── test_config_flow.py   # Config flow tests
-└── test_websocket.py     # WebSocket tests
+├── test_init.py          # Integration setup tests
+└── test_ha_stage.py      # Deploy helper tests (mocked)
 ```
 
 ## Dependencies
@@ -268,6 +292,12 @@ tests/
 
 ## Version History
 
+- **v0.5.x** - Reliability/quality fixes (issue #21): deterministic serial/IP identity, unified
+  entity/config-entry unique_id, position-timestamp and negative-duration guards, malformed-JSON
+  tolerance in polling
+- **v0.5.0** - Configurable integer volume step (1-20%) with options-flow reconfigure support
+- **v0.4.x** - Device-registry integration, serial-based unique_id, options-flow reload,
+  `state.py`/`client.py` consolidation (WebSocket folded into `client.py`, `websocket.py` removed)
 - **v0.2.0** - WebSocket real-time updates, debounce mechanism, enhanced error handling
 - **v0.1.1** - Config flow UI, improved setup
 - **v0.1.0** - Initial release

--- a/custom_components/naim_media_player/client.py
+++ b/custom_components/naim_media_player/client.py
@@ -110,7 +110,7 @@ class NaimClient:
         unreachable device; nowplaying and levels/room are fetched
         concurrently to keep polling fast.
         """
-        power = await self._get_json_safe("power", retries=1)
+        power = await self._get_json_safe("power", single_attempt=True)
         if power is None:
             await self._state.update(source="poll", available=False)
             return
@@ -122,8 +122,8 @@ class NaimClient:
             return
 
         nowplaying, levels = await asyncio.gather(
-            self._get_json_safe("nowplaying", retries=1),
-            self._get_json_safe("levels/room", retries=1),
+            self._get_json_safe("nowplaying", single_attempt=True),
+            self._get_json_safe("levels/room", single_attempt=True),
         )
         nowplaying = nowplaying or {}
         levels = levels or {}
@@ -253,14 +253,14 @@ class NaimClient:
 
         await self._state.update(source="websocket", **updates)
 
-    async def _get_json(self, endpoint: str, retries: int | None = None) -> dict[str, Any]:
+    async def _get_json(self, endpoint: str, single_attempt: bool = False) -> dict[str, Any]:
         """Get JSON from an endpoint with retries."""
-        return await self._request("get", endpoint, retries=retries)
+        return await self._request("get", endpoint, single_attempt=single_attempt)
 
-    async def _get_json_safe(self, endpoint: str, retries: int | None = None) -> dict[str, Any] | None:
+    async def _get_json_safe(self, endpoint: str, single_attempt: bool = False) -> dict[str, Any] | None:
         """Get JSON from an endpoint, returning None on failure."""
         try:
-            return await self._get_json(endpoint, retries=retries)
+            return await self._get_json(endpoint, single_attempt=single_attempt)
         except NaimConnectionError as error:
             _LOGGER.debug("Cannot reach device at %s for %s: %s", self._host, endpoint, error)
             return None
@@ -270,16 +270,17 @@ class NaimClient:
         method: str,
         endpoint: str,
         params: dict[str, str | int | bool] | None = None,
-        retries: int | None = None,
+        single_attempt: bool = False,
     ) -> dict[str, Any]:
         """Make an HTTP request with retries.
 
-        `retries` overrides the client's default max_retries; pass a low
-        value (e.g. 1) for latency-sensitive callers like polling.
+        `single_attempt` skips the retry/backoff loop for latency-sensitive
+        callers like polling, where a single failed attempt should surface
+        immediately rather than block for the full retry duration.
         """
         url = f"http://{self._host}:{self._http_port}/{endpoint}"
         request = self._session.get if method == "get" else self._session.put
-        max_retries = retries if retries is not None else self._max_retries
+        max_retries = 1 if single_attempt else self._max_retries
 
         for retry in range(max_retries):
             try:
@@ -300,6 +301,18 @@ class NaimClient:
             except aiohttp.ClientError as error:
                 _LOGGER.warning(
                     "Client error on %s %s (attempt %d/%d): %s",
+                    method.upper(),
+                    endpoint,
+                    retry + 1,
+                    max_retries,
+                    error,
+                )
+            except ValueError as error:
+                # A malformed 200 body (e.g. invalid JSON) raises ValueError/
+                # json.JSONDecodeError from response.json(); treat it like any
+                # other failed attempt instead of letting it escape.
+                _LOGGER.warning(
+                    "Malformed response body on %s %s (attempt %d/%d): %s",
                     method.upper(),
                     endpoint,
                     retry + 1,

--- a/custom_components/naim_media_player/config_flow.py
+++ b/custom_components/naim_media_player/config_flow.py
@@ -52,45 +52,60 @@ def _get_volume_step(config_entry: config_entries.ConfigEntry) -> int:
     )
 
 
+async def _async_fetch_device_json(
+    hass, ip_address: str, path: str, port: int = DEFAULT_HTTP_PORT
+) -> dict[str, Any] | None:
+    """Fetch and parse JSON from a Naim device HTTP endpoint.
+
+    Shared by `async_get_available_inputs` and `async_get_device_serial`.
+    Returns the parsed JSON body, or None on any failure (non-200 status,
+    timeout, client error, or unexpected error).
+    """
+    try:
+        session = async_get_clientsession(hass)
+        timeout = aiohttp.ClientTimeout(total=10)
+        url = f"http://{ip_address}:{port}/{path}"
+
+        async with session.get(url, timeout=timeout) as response:
+            if response.status != 200:
+                _LOGGER.warning("Failed to fetch %s: HTTP %s", path, response.status)
+                return None
+
+            return await response.json()
+
+    except (aiohttp.ClientError, asyncio.TimeoutError) as error:
+        _LOGGER.debug("Failed to fetch %s from %s: %s", path, ip_address, error)
+        return None
+    except Exception as error:
+        _LOGGER.warning("Unexpected error fetching %s: %s", path, error)
+        return None
+
+
 async def async_get_available_inputs(hass, ip_address: str, port: int = DEFAULT_HTTP_PORT) -> dict[str, str] | None:
     """Fetch available inputs from the Naim device.
 
     Returns a dict mapping display name to input ID, or None on failure.
     Only returns inputs with selectable="1".
     """
-    try:
-        session = async_get_clientsession(hass)
-        timeout = aiohttp.ClientTimeout(total=10)
-        url = f"http://{ip_address}:{port}/inputs"
-
-        async with session.get(url, timeout=timeout) as response:
-            if response.status != 200:
-                _LOGGER.warning("Failed to fetch inputs: HTTP %s", response.status)
-                return None
-
-            data = await response.json()
-            children = data.get("children", [])
-
-            # Filter to selectable inputs and build the map
-            sources = {}
-            for child in children:
-                if child.get("selectable") == "1":
-                    name = child.get("name")
-                    ussi = child.get("ussi", "")
-                    # Extract input ID from ussi (e.g., "inputs/ana1" -> "ana1")
-                    input_id = ussi.split("/")[-1] if "/" in ussi else ussi
-                    if name and input_id:
-                        sources[name] = input_id
-
-            _LOGGER.debug("Discovered %d selectable inputs: %s", len(sources), list(sources.keys()))
-            return sources
-
-    except (aiohttp.ClientError, asyncio.TimeoutError) as error:
-        _LOGGER.debug("Failed to fetch inputs from %s: %s", ip_address, error)
+    data = await _async_fetch_device_json(hass, ip_address, "inputs", port)
+    if data is None:
         return None
-    except Exception as error:
-        _LOGGER.warning("Unexpected error fetching inputs: %s", error)
-        return None
+
+    children = data.get("children", [])
+
+    # Filter to selectable inputs and build the map
+    sources = {}
+    for child in children:
+        if child.get("selectable") == "1":
+            name = child.get("name")
+            ussi = child.get("ussi", "")
+            # Extract input ID from ussi (e.g., "inputs/ana1" -> "ana1")
+            input_id = ussi.split("/")[-1] if "/" in ussi else ussi
+            if name and input_id:
+                sources[name] = input_id
+
+    _LOGGER.debug("Discovered %d selectable inputs: %s", len(sources), list(sources.keys()))
+    return sources
 
 
 async def async_get_device_serial(hass, ip_address: str, port: int = DEFAULT_HTTP_PORT) -> str | None:
@@ -98,26 +113,12 @@ async def async_get_device_serial(hass, ip_address: str, port: int = DEFAULT_HTT
 
     Returns the serial as a string, or None if it could not be determined.
     """
-    try:
-        session = async_get_clientsession(hass)
-        timeout = aiohttp.ClientTimeout(total=10)
-        url = f"http://{ip_address}:{port}/system"
-
-        async with session.get(url, timeout=timeout) as response:
-            if response.status != 200:
-                _LOGGER.warning("Failed to fetch device info: HTTP %s", response.status)
-                return None
-
-            data = await response.json()
-            serial = data.get("serial")
-            return str(serial) if serial else None
-
-    except (aiohttp.ClientError, asyncio.TimeoutError) as error:
-        _LOGGER.debug("Failed to fetch serial from %s: %s", ip_address, error)
+    data = await _async_fetch_device_json(hass, ip_address, "system", port)
+    if data is None:
         return None
-    except Exception as error:
-        _LOGGER.warning("Unexpected error fetching device serial: %s", error)
-        return None
+
+    serial = data.get("serial")
+    return str(serial) if serial else None
 
 
 def valid_ip_address(value: str) -> bool:
@@ -241,17 +242,35 @@ class NaimConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         # At this point, the IP is valid and the device is reachable.
+        ip = validated_input[CONF_IP_ADDRESS]
+
+        # A device re-added after the serial-based unique_id migration must
+        # still be recognized as already configured: an existing entry keyed
+        # by the legacy bare-IP unique_id (or any entry stored against this
+        # IP) is the same device even if this run's /system fetch resolves
+        # differently. Checking the stored IP first keeps identity
+        # deterministic and prevents a duplicate entry regardless of whether
+        # the existing entry was keyed by serial or by IP.
+        for entry in self._async_current_entries():
+            if entry.data.get(CONF_IP_ADDRESS) == ip:
+                return self.async_abort(reason="already_configured")
+
         # Prefer a stable unique ID based on the device serial (survives DHCP
-        # address changes); fall back to the IP address if it can't be fetched.
-        serial = await async_get_device_serial(self.hass, validated_input[CONF_IP_ADDRESS])
-        await self.async_set_unique_id(serial or validated_input[CONF_IP_ADDRESS])
+        # address changes); fall back to the IP address if it can't be
+        # fetched. Fetch the serial and the available inputs concurrently to
+        # avoid two sequential 10s-timeout round-trips during setup.
+        serial, self._available_sources = await asyncio.gather(
+            async_get_device_serial(self.hass, ip),
+            async_get_available_inputs(self.hass, ip),
+        )
+        self._available_sources = self._available_sources or {}
+        await self.async_set_unique_id(serial or ip)
         self._abort_if_unique_id_configured()
 
-        # Store the user input and try to discover sources
+        # Store the user input
         self._user_input = validated_input
         if serial:
             self._user_input[CONF_SERIAL] = serial
-        self._available_sources = await async_get_available_inputs(self.hass, validated_input[CONF_IP_ADDRESS]) or {}
 
         # If we discovered sources, show the selection step
         if self._available_sources:

--- a/custom_components/naim_media_player/media_player.py
+++ b/custom_components/naim_media_player/media_player.py
@@ -49,7 +49,7 @@ async def async_setup_entry(
     serial = entry.data.get(CONF_SERIAL)
 
     async_add_entities(
-        [NaimPlayer(hass, name, ip_address, entity_id, volume_step, sources, serial)],
+        [NaimPlayer(hass, name, ip_address, entity_id, volume_step, sources, serial, entry.unique_id)],
         True,
     )
 
@@ -78,8 +78,16 @@ class NaimPlayer(MediaPlayerEntity):
         volume_step: float = DEFAULT_VOLUME_STEP,
         sources: dict[str, str] | None = None,
         serial: str | None = None,
+        unique_id: str | None = None,
     ) -> None:
-        """Initialize the media player."""
+        """Initialize the media player.
+
+        `unique_id` should be the config entry's unique_id (computed once by
+        config_flow.py from `serial or ip_address`), so the entity never
+        derives a different identity than the config entry. If omitted (e.g.
+        direct instantiation), it falls back to the same `serial or
+        ip_address` rule to avoid a second, competing fallback string.
+        """
         _LOGGER.info("Initializing Naim media player: %s at %s", name, ip_address)
         self._hass = hass
         self._name = name
@@ -90,7 +98,7 @@ class NaimPlayer(MediaPlayerEntity):
             self.entity_id = f"media_player.{entity_id}"
         # Otherwise leave entity_id unset so Home Assistant derives it from the name.
 
-        self._attr_unique_id = serial if serial else f"naim_{ip_address}"
+        self._attr_unique_id = unique_id or serial or ip_address
         self._attr_device_info = (
             DeviceInfo(
                 identifiers={(DOMAIN, serial)},

--- a/custom_components/naim_media_player/state.py
+++ b/custom_components/naim_media_player/state.py
@@ -101,6 +101,11 @@ class NaimPlayerState:
             for key, value in kwargs.items():
                 attr_name = "source" if key == "source_name" else key
 
+                if attr_name == "duration" and isinstance(value, (int, float)) and value < 0:
+                    # Naim devices report a negative duration (e.g. -0.001) for
+                    # endless streams such as web radio; treat as "no duration".
+                    value = None
+
                 if attr_name in MEDIA_INFO_FIELDS:
                     target = self.media_info
                     target_attr = attr_name
@@ -127,8 +132,8 @@ class NaimPlayerState:
                     setattr(target, target_attr, value)
                     changed = True
 
-                if attr_name == "position":
-                    self.media_info.position_updated_at = dt_util.utcnow()
+                    if attr_name == "position" and value is not None:
+                        self.media_info.position_updated_at = dt_util.utcnow()
 
         if changed and self._on_change:
             result = self._on_change()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -84,6 +84,33 @@ async def test_get_value_client_error_retries_then_succeeds(hass, state):
     assert result == "success"
 
 
+async def test_get_value_malformed_json_eventually_raises(hass, state):
+    """A malformed 200 JSON body must degrade like any other failed request, not raise ValueError."""
+    client = NaimClient(hass, "192.168.1.100", 15081, 4545, state, max_retries=1)
+    with aioresponses() as mock:
+        mock.get(
+            "http://192.168.1.100:15081/test",
+            body="not json",
+            content_type="application/json",
+        )
+        with pytest.raises(NaimConnectionError):
+            await client.get_value("test", "test_var")
+
+
+async def test_get_value_malformed_json_retries_then_succeeds(hass, state):
+    """A single malformed body must be retried like a transient failure, not fatal immediately."""
+    client = NaimClient(hass, "192.168.1.100", 15081, 4545, state, max_retries=2)
+    with aioresponses() as mock:
+        mock.get(
+            "http://192.168.1.100:15081/test",
+            body="not json",
+            content_type="application/json",
+        )
+        mock.get("http://192.168.1.100:15081/test", payload={"test_var": "success"})
+        result = await client.get_value("test", "test_var")
+    assert result == "success"
+
+
 async def test_set_value_success(hass, state):
     """Test successful set_value call."""
     client = NaimClient(hass, "192.168.1.100", 15081, 4545, state)
@@ -251,6 +278,29 @@ async def test_poll_state_device_off(hass, state):
     assert state.power_state == MediaPlayerState.OFF
 
 
+async def test_poll_state_tolerates_malformed_json_without_orphaning_sibling(hass, state):
+    """A malformed nowplaying body must not crash poll_state or drop the levels/room fetch."""
+    client = NaimClient(hass, "192.168.1.100", 15081, 4545, state, max_retries=3)
+    with aioresponses() as mock:
+        mock.get("http://192.168.1.100:15081/power", payload={"system": "on"})
+        mock.get(
+            "http://192.168.1.100:15081/nowplaying",
+            body="not json",
+            content_type="application/json",
+        )
+        mock.get(
+            "http://192.168.1.100:15081/levels/room",
+            payload={"volume": "50", "mute": "0"},
+        )
+        # poll_state must complete without raising, and the sibling fetch's
+        # result must still be consumed.
+        await client.poll_state()
+
+    assert state.available is True
+    assert state.volume == 0.5
+    assert state.muted is False
+
+
 async def test_poll_state_device_unreachable(hass, state):
     """Test poll_state when device is unreachable."""
     state.available = True
@@ -261,8 +311,8 @@ async def test_poll_state_device_unreachable(hass, state):
     assert state.available is False
 
 
-async def test_poll_state_uses_single_retry_request_path(hass, state):
-    """Polling must use a low-retry (single attempt) request path, not the default retries."""
+async def test_poll_state_uses_single_attempt_request_path(hass, state):
+    """Polling must use a single-attempt request path, not the client's default retries."""
     client = NaimClient(hass, "192.168.1.100", 15081, 4545, state, max_retries=5)
     responses = {
         "power": {"system": "on"},
@@ -270,7 +320,7 @@ async def test_poll_state_uses_single_retry_request_path(hass, state):
         "levels/room": {"volume": "50", "mute": "0"},
     }
 
-    async def fake_request(method, endpoint, params=None, retries=None):
+    async def fake_request(method, endpoint, params=None, single_attempt=False):
         return responses[endpoint]
 
     with patch.object(client, "_request", new=AsyncMock(side_effect=fake_request)) as mock_request:
@@ -278,14 +328,14 @@ async def test_poll_state_uses_single_retry_request_path(hass, state):
 
     assert mock_request.call_args_list
     for call in mock_request.call_args_list:
-        assert call.kwargs.get("retries") == 1
+        assert call.kwargs.get("single_attempt") is True
 
 
 async def test_poll_state_fetches_nowplaying_and_levels_concurrently(hass, state):
     """nowplaying and levels/room must be fetched concurrently, not sequentially."""
     client = NaimClient(hass, "192.168.1.100", 15081, 4545, state)
 
-    async def fake_request(method, endpoint, params=None, retries=None):
+    async def fake_request(method, endpoint, params=None, single_attempt=False):
         if endpoint == "power":
             return {"system": "on"}
         await asyncio.sleep(0.2)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test the Naim Media Player config flow."""
 
 import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -14,6 +15,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.naim_media_player.config_flow import (
     NaimConfigFlow,
     NaimOptionsFlow,
+    _async_fetch_device_json,
     async_get_available_inputs,
     async_get_device_serial,
 )
@@ -262,6 +264,40 @@ async def test_async_get_available_inputs_unexpected_error(hass: HomeAssistant) 
     assert result is None
 
 
+# Tests for the shared HTTP-fetch helper used by both discovery functions
+
+
+async def test_available_inputs_and_serial_share_fetch_helper(hass: HomeAssistant) -> None:
+    """Both discovery functions must delegate to the same fetch helper, not duplicate the scaffolding."""
+    with patch(
+        "custom_components.naim_media_player.config_flow._async_fetch_device_json",
+        new=AsyncMock(return_value=None),
+    ) as mock_fetch:
+        await async_get_available_inputs(hass, "192.168.1.100")
+        await async_get_device_serial(hass, "192.168.1.100")
+
+    assert mock_fetch.await_count == 2
+    fetched_paths = {call.args[2] for call in mock_fetch.await_args_list}
+    assert fetched_paths == {"inputs", "system"}
+
+
+async def test_fetch_device_json_returns_none_on_http_error(hass: HomeAssistant) -> None:
+    """The shared helper returns None on a non-200 response."""
+    mock_response = AsyncMock()
+    mock_response.status = 500
+
+    mock_session = MagicMock()
+    mock_session.get = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response)))
+
+    with patch(
+        "custom_components.naim_media_player.config_flow.async_get_clientsession",
+        return_value=mock_session,
+    ):
+        result = await _async_fetch_device_json(hass, "192.168.1.100", "system")
+
+    assert result is None
+
+
 # Tests for async_get_device_serial
 
 
@@ -409,6 +445,156 @@ async def test_form_falls_back_to_ip_when_serial_unavailable(hass: HomeAssistant
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert entry.unique_id == "192.168.1.100"
+
+
+async def test_form_fetches_serial_and_inputs_concurrently(hass: HomeAssistant) -> None:
+    """Serial and inputs discovery must run concurrently, not as two sequential round-trips."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+
+    mock_writer = MagicMock()
+    mock_writer.close.return_value = None
+    mock_writer.wait_closed = MagicMock(return_value=asyncio.Future())
+    mock_writer.wait_closed.return_value.set_result(None)
+
+    async def slow_serial(*_args, **_kwargs):
+        await asyncio.sleep(0.2)
+        return "SERIAL123"
+
+    async def slow_inputs(*_args, **_kwargs):
+        await asyncio.sleep(0.2)
+        return None
+
+    with (
+        patch("asyncio.open_connection", return_value=(MagicMock(), mock_writer)),
+        patch(
+            "custom_components.naim_media_player.config_flow.async_get_available_inputs",
+            side_effect=slow_inputs,
+        ),
+        patch(
+            "custom_components.naim_media_player.config_flow.async_get_device_serial",
+            side_effect=slow_serial,
+        ),
+    ):
+        start = time.monotonic()
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_IP_ADDRESS: "192.168.1.100",
+                CONF_NAME: "Test Naim",
+                "entity_id": "test_naim",
+                CONF_VOLUME_STEP: 5,
+            },
+        )
+        elapsed = time.monotonic() - start
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert elapsed < 0.35
+
+
+# Tests for duplicate-entry detection across the serial/IP identity migration
+
+
+async def test_reconfigure_ip_keyed_entry_aborts_even_when_serial_now_available(
+    hass: HomeAssistant,
+) -> None:
+    """A pre-migration entry keyed by bare IP must be recognized even if this run fetches a serial.
+
+    Without a same-IP check, `async_set_unique_id(serial or ip)` would compute a
+    different unique_id than the existing IP-keyed entry and create a duplicate.
+    """
+    existing = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.1.100",
+        title="Test Naim",
+        data={CONF_IP_ADDRESS: "192.168.1.100", CONF_NAME: "Test Naim"},
+    )
+    existing.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+
+    mock_writer = MagicMock()
+    mock_writer.close.return_value = None
+    mock_writer.wait_closed = MagicMock(return_value=asyncio.Future())
+    mock_writer.wait_closed.return_value.set_result(None)
+
+    with (
+        patch("asyncio.open_connection", return_value=(MagicMock(), mock_writer)),
+        patch(
+            "custom_components.naim_media_player.config_flow.async_get_available_inputs",
+            return_value=None,
+        ),
+        patch(
+            "custom_components.naim_media_player.config_flow.async_get_device_serial",
+            return_value="SERIAL123",
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_IP_ADDRESS: "192.168.1.100",
+                CONF_NAME: "Test Naim",
+                "entity_id": "test_naim",
+                CONF_VOLUME_STEP: 5,
+            },
+        )
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "already_configured"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+
+async def test_reconfigure_serial_keyed_entry_aborts_even_when_serial_fetch_is_flaky(
+    hass: HomeAssistant,
+) -> None:
+    """A serial-keyed entry must still be recognized when a later /system fetch flakily fails.
+
+    The IP match must catch this case so identity never silently flips from
+    serial back to a bare-IP duplicate.
+    """
+    existing = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="SERIAL123",
+        title="Test Naim",
+        data={
+            CONF_IP_ADDRESS: "192.168.1.100",
+            CONF_NAME: "Test Naim",
+            CONF_SERIAL: "SERIAL123",
+        },
+    )
+    existing.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+
+    mock_writer = MagicMock()
+    mock_writer.close.return_value = None
+    mock_writer.wait_closed = MagicMock(return_value=asyncio.Future())
+    mock_writer.wait_closed.return_value.set_result(None)
+
+    with (
+        patch("asyncio.open_connection", return_value=(MagicMock(), mock_writer)),
+        patch(
+            "custom_components.naim_media_player.config_flow.async_get_available_inputs",
+            return_value=None,
+        ),
+        patch(
+            "custom_components.naim_media_player.config_flow.async_get_device_serial",
+            return_value=None,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_IP_ADDRESS: "192.168.1.100",
+                CONF_NAME: "Test Naim",
+                "entity_id": "test_naim",
+                CONF_VOLUME_STEP: 5,
+            },
+        )
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "already_configured"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
 # Tests for source selection step

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -8,10 +8,12 @@ from homeassistant.components.media_player import (
     MediaPlayerEntityFeature,
     MediaPlayerState,
 )
+from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME
 from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.naim_media_player.const import DOMAIN
-from custom_components.naim_media_player.media_player import NaimPlayer
+from custom_components.naim_media_player.const import CONF_SERIAL, DOMAIN
+from custom_components.naim_media_player.media_player import NaimPlayer, async_setup_entry
 
 
 @pytest.fixture
@@ -132,11 +134,22 @@ async def test_entity_id_explicit_still_honored(hass):
 
 
 async def test_unique_id_falls_back_to_ip_without_serial(hass):
-    """Without a serial, unique_id falls back to the IP-derived value for backward compat."""
+    """Without a serial or an explicit unique_id, unique_id falls back to the bare IP.
+
+    This is the same bare-IP fallback config_flow.py uses, so entity and
+    config-entry identity never drift.
+    """
     with patch("custom_components.naim_media_player.media_player.NaimClient"):
         player = NaimPlayer(hass, "Test Naim", "192.168.1.100")
-    assert player.unique_id == "naim_192.168.1.100"
+    assert player.unique_id == "192.168.1.100"
     assert player.device_info is None
+
+
+async def test_unique_id_prefers_explicit_value_over_serial_and_ip(hass):
+    """An explicitly passed unique_id (from the config entry) takes priority."""
+    with patch("custom_components.naim_media_player.media_player.NaimClient"):
+        player = NaimPlayer(hass, "Test Naim", "192.168.1.100", serial="SERIAL123", unique_id="ENTRY_UNIQUE_ID")
+    assert player.unique_id == "ENTRY_UNIQUE_ID"
 
 
 async def test_unique_id_uses_serial_when_available(hass):
@@ -354,3 +367,53 @@ async def test_cleanup(mock_player):
     """Test cleanup stops websocket."""
     await mock_player.async_will_remove_from_hass()
     mock_player._client.stop_websocket.assert_called_once()
+
+
+# --- Config-entry / entity unique_id identity tests ---
+
+
+async def test_async_setup_entry_unique_id_matches_entry_for_serial(hass):
+    """The entity's unique_id must equal the config entry's unique_id in the serial case."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="SERIAL123",
+        data={
+            CONF_IP_ADDRESS: "192.168.1.100",
+            CONF_NAME: "Test Naim",
+            CONF_SERIAL: "SERIAL123",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    added_entities: list[NaimPlayer] = []
+
+    def fake_add_entities(entities, update_before_add=False):
+        added_entities.extend(entities)
+
+    with patch("custom_components.naim_media_player.media_player.NaimClient"):
+        await async_setup_entry(hass, entry, fake_add_entities)
+
+    assert added_entities[0].unique_id == entry.unique_id == "SERIAL123"
+
+
+async def test_async_setup_entry_unique_id_matches_entry_for_ip_fallback(hass):
+    """The entity's unique_id must equal the config entry's unique_id in the IP-fallback case."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.1.100",
+        data={
+            CONF_IP_ADDRESS: "192.168.1.100",
+            CONF_NAME: "Test Naim",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    added_entities: list[NaimPlayer] = []
+
+    def fake_add_entities(entities, update_before_add=False):
+        added_entities.extend(entities)
+
+    with patch("custom_components.naim_media_player.media_player.NaimClient"):
+        await async_setup_entry(hass, entry, fake_add_entities)
+
+    assert added_entities[0].unique_id == entry.unique_id == "192.168.1.100"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -245,6 +245,24 @@ class TestNaimPlayerStateUpdate:
         assert state.media_info.image_url == "http://example.com/img.jpg"
         assert state.media_info.position == 45
 
+    async def test_update_clamps_negative_duration_to_none(self):
+        """Naim devices report -0.001 duration for endless radio streams; clamp to None."""
+        state = NaimPlayerState()
+        await state.update(source="poll", duration=-0.001)
+        assert state.media_info.duration is None
+
+    async def test_update_zero_duration_passes_through(self):
+        """Zero duration is a legitimate value and must not be clamped."""
+        state = NaimPlayerState()
+        await state.update(source="poll", duration=0)
+        assert state.media_info.duration == 0
+
+    async def test_update_positive_duration_passes_through(self):
+        """Positive durations are unaffected by the negative-duration clamp."""
+        state = NaimPlayerState()
+        await state.update(source="poll", duration=180)
+        assert state.media_info.duration == 180
+
     async def test_update_ignores_unknown_fields(self):
         """Unknown kwargs should be silently ignored."""
         state = NaimPlayerState()
@@ -562,14 +580,14 @@ class TestMediaPositionUpdatedAt:
         assert state.media_position_updated_at is not None
         assert before <= state.media_position_updated_at <= after
 
-    async def test_position_timestamp_refreshes_on_each_update(self):
-        """The timestamp should update whenever position is set, poll or websocket."""
+    async def test_position_timestamp_refreshes_when_position_changes(self):
+        """The timestamp should update whenever position genuinely changes, poll or websocket."""
         state = NaimPlayerState()
         await state.update(source="poll", position=10)
         first_timestamp = state.media_position_updated_at
 
         await asyncio.sleep(0.01)
-        await state.update(source="websocket", position=10)
+        await state.update(source="websocket", position=15)
         second_timestamp = state.media_position_updated_at
 
         assert second_timestamp > first_timestamp
@@ -579,3 +597,29 @@ class TestMediaPositionUpdatedAt:
         state = NaimPlayerState()
         await state.update(source="poll", title="Song")
         assert state.media_position_updated_at is None
+
+    async def test_unchanged_position_does_not_refresh_timestamp(self):
+        """Repeating the same position value must not rewrite the interpolation baseline."""
+        state = NaimPlayerState()
+        await state.update(source="poll", position=10)
+        first_timestamp = state.media_position_updated_at
+
+        await asyncio.sleep(0.01)
+        await state.update(source="poll", position=10)
+
+        assert state.media_position_updated_at == first_timestamp
+
+    async def test_none_position_does_not_set_or_refresh_timestamp(self):
+        """A None position (e.g. no track playing) must not create or refresh the timestamp."""
+        state = NaimPlayerState()
+        await state.update(source="poll", position=None)
+        assert state.media_position_updated_at is None
+
+        await state.update(source="poll", position=10)
+        first_timestamp = state.media_position_updated_at
+
+        await asyncio.sleep(0.01)
+        await state.update(source="poll", position=None)
+
+        assert state.media_position_updated_at == first_timestamp
+        assert state.media_info.position is None


### PR DESCRIPTION
## Goal

Address the fast-follow code-review findings tracked in issue #21 — the adversarially-verified backlog from the PR #20 review. The two most severe findings (entity_id-unset regression, availability/WebSocket coupling) were already fixed on that branch; this PR clears the rest: correctness fixes, cleanup, and stale docs.

Closes #21

## Changes

**Correctness**
- [x] **Duplicate entries on re-add after unique_id migration** (`config_flow.py`) — the user flow now iterates `_async_current_entries()` and aborts `already_configured` on a matching `CONF_IP_ADDRESS` *before* the serial fetch, so re-adding an already-configured device is detected whether the existing entry is keyed by serial or IP. Identity no longer silently flips between serial and IP when `/system` is flaky.
- [x] **`position_updated_at` refreshed outside the value-changed guard** (`state.py`) — the interpolation baseline is now refreshed only when `position` actually changes to a non-`None` value; unchanged or `None` positions leave it untouched.
- [x] **`json.JSONDecodeError` escapes `_request`** (`client.py`) — `_request` now catches `ValueError`, so a malformed 200 body degrades gracefully to a failed request / `None` on the safe path. `poll_state` completes and never orphans its concurrent sibling fetch.
- [x] **Negative `media_duration` passed through** (`state.py`) — negative durations (e.g. `-0.001` on endless radio streams) are clamped to `None`; zero and positive pass through unchanged.

**Cleanup**
- [x] **Duplicated HTTP-fetch boilerplate** — extracted shared `_async_fetch_device_json` helper; both `async_get_device_serial` and `async_get_available_inputs` delegate to it.
- [x] **`retries` passthrough knob** — replaced the general-purpose `retries` knob threaded through three layers with a clearly-named boolean `single_attempt`.
- [x] **Sequential config-flow fetches** — serial and inputs are now fetched concurrently via a single `asyncio.gather` (~20s worst case ⇒ ~10s).
- [x] **Identity fallback rule duplicated** — the serial-vs-IP identity is computed once in the config flow and stored in entry data; the entity reads `entry.unique_id`. One rule, one string, no drift.

**Docs**
- [x] **CLAUDE.md stale** — refreshed to match current architecture: removed `websocket.py` and the optimistic-update-then-revert pattern, updated to document `state.py`, consolidated `client.py`, serial/device-registry identity, integer volume step, and options reload.

## Build

One continuous TDD build on branch `pge/prepare-a-pr-to-address-the-issues-in-is` (4 commits). Every behavior change landed with a test that fails against the pre-fix code, covered in the existing `tests/` files. No new runtime dependencies; `manifest.json` requirements stays `[]`.

## Gates (final, all green)

- `uv run ruff check custom_components/ tests/` → clean
- `uv run ruff format --check custom_components/ tests/` → 14 files already formatted
- `uv run pytest tests/ -v --timeout=10` → **185 passed**

## Acceptance

- All three gate commands pass.
- Each unchecked issue #21 box is addressed with a corresponding behavior-locking test:
  - Re-add aborts `already_configured` for both IP-keyed and serial-keyed existing entries (`test_config_flow.py`).
  - `position` update that is unchanged/`None` does not touch `position_updated_at`; a changed one does (`test_state.py`).
  - Malformed 200 body does not raise out of `poll_state` and does not orphan the sibling fetch (`test_client.py`).
  - Negative reported duration surfaces as `media_duration is None` (`test_state.py`).
  - Config-entry `unique_id` and entity `unique_id` derive from one shared rule, asserted for both serial and IP-fallback cases (`test_media_player.py`).

## Adversarial evaluation summary

The build passed adversarial evaluation on pass 1 (verified live 2026-07-04, branch @ 8044341). All gates ran clean (185 passed). Every rubric item was verified against source and diffed against master to confirm a real behavior change:

- Re-add never duplicates — a new abort loop in `config_flow.py` matches `CONF_IP_ADDRESS` before the serial fetch; master lacked it.
- Identity deterministic with a single fallback string — a grep for competing `naim_{...}` literals finds none; the entity reads `entry.unique_id`.
- `position_updated_at` assigned only inside the `!= value` branch and only for non-`None` positions; master set it unconditionally.
- Malformed-JSON tolerance — `_request` now catches `ValueError` → `NaimConnectionError` → `_get_json_safe` returns `None`; the sibling fetch in `poll_state` is still consumed.
- Negative-duration clamp with zero/positive passthrough; master had no clamp.
- Shared `_async_fetch_device_json` helper; `retries` knob replaced by boolean `single_attempt`; concurrent `asyncio.gather` in setup (timing test asserts fast path).
- CLAUDE.md refreshed; layering clean (no config-flow/CLI imports in state/client/media_player); `manifest.json` requirements `[]`; `pyproject.toml` unchanged.

The only open item was the PR/branch-push itself — the autonomous-PR stage that runs after a passing verdict — which this PR fulfils. No Critical or High findings remained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
