### PR TITLE
🐛 fix: read device serial from hardwareSerial key in /system payload

### DIFF
--- a/custom_components/naim_media_player/config_flow.py
+++ b/custom_components/naim_media_player/config_flow.py
@@ -117,7 +117,9 @@ async def async_get_device_serial(hass, ip_address: str, port: int = DEFAULT_HTT
     if data is None:
         return None
 
-    serial = data.get("serial")
+    # Naim firmware exposes the device serial as "hardwareSerial"; older
+    # assumptions used a bare "serial" key, kept as a fallback.
+    serial = data.get("hardwareSerial") or data.get("serial")
     return str(serial) if serial else None
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -302,7 +302,36 @@ async def test_fetch_device_json_returns_none_on_http_error(hass: HomeAssistant)
 
 
 async def test_async_get_device_serial_success(hass: HomeAssistant) -> None:
-    """Test fetching the device serial from the /system endpoint."""
+    """Test fetching the device serial from the /system endpoint.
+
+    Real Naim firmware (Atom, fw 3.12) exposes the serial as "hardwareSerial";
+    there is no bare "serial" key. Payload mirrors an actual device response.
+    """
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "name": "system",
+            "chromecastSerial": "386EAFB080E8E8B7",
+            "hardwareSerial": "521103",
+            "hardwareType": "stream800",
+        }
+    )
+
+    mock_session = MagicMock()
+    mock_session.get = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response)))
+
+    with patch(
+        "custom_components.naim_media_player.config_flow.async_get_clientsession",
+        return_value=mock_session,
+    ):
+        result = await async_get_device_serial(hass, "192.168.1.100")
+
+    assert result == "521103"
+
+
+async def test_async_get_device_serial_legacy_serial_key(hass: HomeAssistant) -> None:
+    """Test falling back to a bare "serial" key if hardwareSerial is absent."""
     mock_response = AsyncMock()
     mock_response.status = 200
     mock_response.json = AsyncMock(return_value={"serial": "ABC123"})


### PR DESCRIPTION
## Problem

Serial discovery during config flow setup always returned `None`: `async_get_device_serial` read `data.get("serial")`, but real Naim firmware (verified against an Atom on fw 3.12) exposes the serial as `"hardwareSerial"` — there is no bare `"serial"` key.

Consequences on a live install:

- The config entry unique_id silently fell back to the bare IP address instead of the serial, defeating the deterministic-identity work from #20/#22.
- Home Assistant's deleted-entity restore keys on `(platform, unique_id)`. Because the IP-based unique_id matched a previously deleted entity, HA resurrected the stale `media_player.naim_atom_2` entity_id on every re-add — ignoring the entity_id entered in the setup form — leaving dashboards and automations pointing at a dead `media_player.naim_atom`.

The tests never caught this because they mocked the `/system` response as `{"serial": "ABC123"}`, a shape no real device sends.

## Fix

Read `hardwareSerial` first, keeping the bare `serial` key as a fallback.

## Tests

- `test_async_get_device_serial_success` now mirrors a real Atom `/system` payload (`hardwareSerial`, `chromecastSerial`, etc.)
- New `test_async_get_device_serial_legacy_serial_key` covers the fallback
- Full suite: 186 passed; ruff check/format clean
- Verified end-to-end on a live HA install: after re-adding the device, the entity registers as `media_player.naim_atom` with unique_id `521103` (the device serial) and updates in real time

🤖 Generated with [Claude Code](https://claude.com/claude-code)